### PR TITLE
Update pg.js

### DIFF
--- a/db/pg.js
+++ b/db/pg.js
@@ -34,27 +34,26 @@ function showAllMovies (req, res, next){
     })
 }
 
-function addMovies (req, res, next){
-  var poster = req.body.poster;
-  var title = req.body.title;
-  var year = req.body.year;
-  var rated = req.body.rated;
-  var director = req.body.director;
-  var actors = req.body.actors;
-  var plot = req.body.plot;
-  db.any('INSERT INTO movies (poster, title, year, rated, director, actors, plot) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *;', [poster, title, year, rated, director, actors, plot])
-    .then((data)=>{
-      res.rows = data;
-      next();
-    })
-    .catch((error)=>{
-      console.log(error);
-    })
+function addMovies(req, res, next) {
+    var poster = req.body.poster;
+    var title = req.body.title;
+    var year = parseInt(req.body.year);
+    var rated = req.body.rated;
+    var director = req.body.director;
+    var actors = req.body.actors;
+    var plot = req.body.plot;
+    db.one('INSERT INTO movies (poster, title, year, rated, director, actors, plot) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *', [poster, title, year, rated, director, actors, plot])
+        .then((data)=> {
+            res.rows = [data];
+            next();
+        })
+        .catch((error)=> {
+            console.log(error);
+        });
 
 // function showtime
 // db.any(array_agg(s.showtimes)
 // group by m.movie)
-
 
 }
 


### PR DESCRIPTION
- `INSERT` when it returns data should be used with method `one`, because it is expected to return 1 row always. But you still can return it as an array, if you want as shown - `[data]`
- It is a good idea to convert request strings into integers where such are expected by the table
- When no conversion is required, [Named Parameters](https://github.com/vitaly-t/pg-promise#named-parameters) is a better choice for query formatting.
